### PR TITLE
Add a new widget size

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "turnstile-next",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "The Cloudflare Turnstile Client Side Rendering for React and NextJS",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",

--- a/src/Input.tsx
+++ b/src/Input.tsx
@@ -32,7 +32,7 @@ type Props = {
    * @default 'normal'
    * @see https://developers.cloudflare.com/turnstile/get-started/client-side-rendering/#configurations
    **/
-  size?: 'compact' | 'normal'
+  size?: 'flexible' | 'compact' | 'normal'
 
   /**
    * The name of the field that will be used to store the token.


### PR DESCRIPTION
[The Turnstile widget can have two different fixed sizes or a flexible width size when using the Managed or Non-interactive modes](https://developers.cloudflare.com/turnstile/get-started/client-side-rendering/#widget-size)