### PR TITLE
Fix many renders on call refreshTurnstile

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "turnstile-next",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "The Cloudflare Turnstile Client Side Rendering for React and NextJS",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -7,8 +7,9 @@ const defaultClassName = 'cf-turnstile'
 export const refreshTurnstile = (props: Props = {}) => {
   if (typeof window === 'undefined') return
   if ('turnstile' in window) {
+    checkWidgetRender()
     // @ts-ignore
-    window.turnstile.render('.' + (props.className || defaultClassName))
+    window.turnstile.reset('.' + (props.className || defaultClassName))
   }
 }
 
@@ -20,7 +21,8 @@ export const checkWidgetRender = () => {
       window.turnstile.getResponse()
     } catch (err: any) {
       if (err?.message?.includes('not find widget')) {
-        refreshTurnstile()
+        // @ts-ignore
+        window.turnstile.render('.' + defaultClassName)
       }
     }
   }


### PR DESCRIPTION
If you call the refreshTurnstile function several times, the captcha starts to be duplicated. To fix this, replace window.turnstile.render with window.turnstile.reset

[If a given widget has timed out, expired or needs to be reloaded, you can use the turnstile.reset(widgetId: string) function to reset the widget.](https://developers.cloudflare.com/turnstile/get-started/client-side-rendering/#reset-a-widget)